### PR TITLE
Remove the 5 minutes buffer on token expiration check

### DIFF
--- a/internal/accesstoken/token_exchanger.go
+++ b/internal/accesstoken/token_exchanger.go
@@ -131,8 +131,7 @@ func (e *TokenExchanger) ObtainToken(ctx context.Context, code string) error {
 }
 
 func (e *TokenExchanger) refreshTokenIfExpired(ctx context.Context, token T) (T, error) {
-	const buffer = 5 * time.Minute
-	if token.TokenExpiry.After(time.Now().Add(buffer)) {
+	if token.TokenExpiry.After(time.Now()) {
 		// No need to refresh.
 		return token, nil
 	}


### PR DESCRIPTION
It seems DEX doesn't issue a new token even if the current one will expire in 5 minutes.