### PR TITLE
Add 'fine-tuning jobs exec'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cli/browser v1.3.0
 	github.com/cli/go-gh v1.2.1
 	github.com/coreos/go-oidc/v3 v3.10.0
+	github.com/docker/cli v26.1.3+incompatible
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.16.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
@@ -31,8 +32,8 @@ require (
 )
 
 require (
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
-	github.com/creack/pty v1.1.18 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
@@ -55,6 +56,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
+	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/muesli/termenv v0.12.0 // indirect
@@ -63,6 +65,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.22.0 // indirect
 	golang.org/x/net v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkkhIiSjQ=
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -22,6 +24,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docker/cli v26.1.3+incompatible h1:bUpXT/N0kDE3VUHI2r5VMsYQgi38kYuoC0oL9yt3lqc=
+github.com/docker/cli v26.1.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
@@ -110,6 +114,10 @@ github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQ
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
+github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
+github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
+github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -137,6 +145,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -147,6 +157,7 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -187,9 +198,11 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/finetuning/jobs/jobs.go
+++ b/internal/finetuning/jobs/jobs.go
@@ -18,7 +18,6 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1t "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 const (
@@ -36,6 +35,7 @@ func Cmd() *cobra.Command {
 	cmd.AddCommand(listCmd())
 	cmd.AddCommand(getCmd())
 	cmd.AddCommand(cancelCmd())
+	cmd.AddCommand(execCmd())
 	cmd.AddCommand(logsCmd())
 	return cmd
 }
@@ -82,6 +82,22 @@ func cancelCmd() *cobra.Command {
 	return cmd
 }
 
+func execCmd() *cobra.Command {
+	var (
+		id string
+	)
+	cmd := &cobra.Command{
+		Use:  "exec",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return exec(cmd.Context(), id)
+		},
+	}
+	cmd.Flags().StringVar(&id, "id", "", "ID of the job")
+	_ = cmd.MarkFlagRequired("id")
+	return cmd
+}
+
 func logsCmd() *cobra.Command {
 	var (
 		id string
@@ -94,7 +110,7 @@ func logsCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&id, "id", "", "ID of the job")
-	_ = cmd.MarkFlagRequired("pod")
+	_ = cmd.MarkFlagRequired("id")
 	return cmd
 }
 
@@ -180,39 +196,15 @@ func cancel(ctx context.Context, id string) error {
 }
 
 func logs(ctx context.Context, id string) error {
-	env, err := runtime.NewEnv(ctx)
+	pods, err := listPodsForJob(ctx, id)
 	if err != nil {
 		return err
-	}
-
-	c := ihttp.NewClient(env)
-
-	var job jv1.Job
-	if err := c.Send(http.MethodGet, fmt.Sprintf("%s/%s", path, id), &jv1.GetJobRequest{}, &job); err != nil {
-		return err
-	}
-	namespace := job.KubernetesNamespace
-
-	kc, err := k8s.NewClient(env)
-	if err != nil {
-		return err
-	}
-	podClient := kc.CoreV1().Pods(namespace)
-	resp, err := podClient.List(ctx, metav1.ListOptions{
-		// This is an implicit assumption that the pod name is "job-<job_id>".
-		LabelSelector: fmt.Sprintf("job-name=job-%s", id),
-	})
-	if err != nil {
-		return err
-	}
-	if len(resp.Items) == 0 {
-		return fmt.Errorf("no pod found for the job %q", id)
 	}
 
 	// Choose the latest pod or the last failed job.
 	var latestPod *corev1.Pod
 	var lastFailed *corev1.Pod
-	for _, pod := range resp.Items {
+	for _, pod := range pods {
 		if latestPod == nil || pod.CreationTimestamp.After(latestPod.CreationTimestamp.Time) {
 			latestPod = &pod
 		}
@@ -226,14 +218,23 @@ func logs(ctx context.Context, id string) error {
 	}
 
 	if lastFailed != nil {
-		return podLog(ctx, podClient, lastFailed)
+		return podLog(ctx, lastFailed)
 	}
 
-	return podLog(ctx, podClient, latestPod)
+	return podLog(ctx, latestPod)
 }
 
-func podLog(ctx context.Context, client corev1t.PodInterface, pod *corev1.Pod) error {
-	req := client.GetLogs(pod.Name, &corev1.PodLogOptions{
+func podLog(ctx context.Context, pod *corev1.Pod) error {
+	env, err := runtime.NewEnv(ctx)
+	if err != nil {
+		return nil
+	}
+	kc, err := k8s.NewClient(env)
+	if err != nil {
+		return err
+	}
+
+	req := kc.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
 		Follow: true,
 	})
 	stream, err := req.Stream(ctx)
@@ -248,4 +249,69 @@ func podLog(ctx context.Context, client corev1t.PodInterface, pod *corev1.Pod) e
 		return err
 	}
 	return nil
+}
+
+func exec(ctx context.Context, id string) error {
+	pods, err := listPodsForJob(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	// Choose the latest pod for the job.
+	var latestPod *corev1.Pod
+	for _, pod := range pods {
+		if latestPod == nil || pod.CreationTimestamp.After(latestPod.CreationTimestamp.Time) {
+			latestPod = &pod
+		}
+	}
+
+	if latestPod == nil {
+		return fmt.Errorf("no pod found for the job %q", id)
+	}
+
+	if latestPod.Status.Phase != corev1.PodRunning {
+		return fmt.Errorf("the pod is not running")
+	}
+
+	return k8s.ExecPod(ctx, latestPod)
+}
+
+func listPodsForJob(ctx context.Context, id string) ([]corev1.Pod, error) {
+	env, err := runtime.NewEnv(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	job, err := getJob(env, id)
+	if err != nil {
+		return nil, err
+	}
+	namespace := job.KubernetesNamespace
+
+	kc, err := k8s.NewClient(env)
+	if err != nil {
+		return nil, err
+	}
+	podClient := kc.CoreV1().Pods(namespace)
+	resp, err := podClient.List(ctx, metav1.ListOptions{
+		// This is an implicit assumption that the pod name is "job-<job_id>".
+		LabelSelector: fmt.Sprintf("job-name=job-%s", id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Items) == 0 {
+		return nil, fmt.Errorf("no pod found for the job %q", id)
+	}
+	return resp.Items, nil
+}
+
+func getJob(env *runtime.Env, id string) (*jv1.Job, error) {
+	var req jv1.GetJobRequest
+	var resp jv1.Job
+	if err := ihttp.NewClient(env).Send(http.MethodGet, fmt.Sprintf("%s/%s", path, id), &req, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
 }

--- a/internal/k8s/exec.go
+++ b/internal/k8s/exec.go
@@ -70,7 +70,7 @@ func ExecPod(ctx context.Context, pod *corev1.Pod) error {
 	}
 	defer in.RestoreTerminal()
 
-	err = exec.Stream(remotecommand.StreamOptions{
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdin:  in,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,

--- a/internal/k8s/exec.go
+++ b/internal/k8s/exec.go
@@ -1,0 +1,84 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/docker/cli/cli/streams"
+	"github.com/llm-operator/cli/internal/runtime"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	rc "k8s.io/apimachinery/pkg/util/remotecommand"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// ExecPod exects into a pod.
+func ExecPod(ctx context.Context, pod *corev1.Pod) error {
+	env, err := runtime.NewEnv(ctx)
+	if err != nil {
+		return nil
+	}
+	kc, err := NewClient(env)
+	if err != nil {
+		return err
+	}
+
+	req := kc.CoreV1().RESTClient().
+		Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec").
+		VersionedParams(
+			&corev1.PodExecOptions{
+				Command: []string{"/bin/bash"},
+				Stdin:   true,
+				Stdout:  true,
+				Stderr:  true,
+				TTY:     true,
+			},
+			scheme.ParameterCodec,
+		)
+
+	// Use SPDY or websocket.
+	// Please note that Kong Ingress Controller does not support SPDY (https://github.com/Kong/kong/discussions/7334).
+	spdyExec, err := remotecommand.NewSPDYExecutor(newConfig(env), http.MethodPost, req.URL())
+	if err != nil {
+		return err
+	}
+	// V5 is the latest protocol that is used from NewWebSocketExecutor(), but a k8s cluster may not support it.
+	wsExec, err := remotecommand.NewWebSocketExecutorForProtocols(newConfig(env), http.MethodGet, req.URL().String(),
+		rc.StreamProtocolV5Name,
+		rc.StreamProtocolV4Name,
+		rc.StreamProtocolV3Name,
+	)
+	if err != nil {
+		return err
+	}
+
+	exec, err := remotecommand.NewFallbackExecutor(wsExec, spdyExec, httpstream.IsUpgradeFailure)
+	if err != nil {
+		return err
+	}
+
+	in := streams.NewIn(os.Stdin)
+	if err := in.SetRawTerminal(); err != nil {
+		return err
+	}
+	defer in.RestoreTerminal()
+
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  in,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+		Tty:    true,
+	})
+	if err != nil {
+		return fmt.Errorf("stream: %s", err)
+	}
+
+	return nil
+}

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -11,11 +11,11 @@ import (
 
 // NewClient creates a new Kubernetes client.
 func NewClient(env *runtime.Env) (kubernetes.Interface, error) {
-	return kubernetes.NewForConfig(NewConfig(env))
+	return kubernetes.NewForConfig(newConfig(env))
 }
 
-// NewConfig creates a new Kubernetes configuration.
-func NewConfig(env *runtime.Env) *rest.Config {
+// newConfig creates a new Kubernetes configuration.
+func newConfig(env *runtime.Env) *rest.Config {
 	return &rest.Config{
 		Host:        fmt.Sprintf("%s/sessions", env.Config.EndpointURL),
 		BearerToken: env.Token.AccessToken,

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -26,7 +26,7 @@ func PortForward(ctx context.Context, pod *corev1.Pod, localPort, remotePort int
 		return nil
 	}
 
-	config := NewConfig(env)
+	config := newConfig(env)
 	url, err := url.Parse(config.Host)
 	if err != nil {
 		return err


### PR DESCRIPTION
There were several pitfalls, but it's working now.

- Kong doesn't support SPDY. We need to use websocket.
- The StreamProtocolV5 protocol, which is a default protocol for websocket, was not supported in v1.29.