### PR TITLE
Ask a user to set a context after 'auth login'

### DIFF
--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/llm-operator/cli/internal/accesstoken"
 	"github.com/llm-operator/cli/internal/configs"
+	"github.com/llm-operator/cli/internal/context"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +31,6 @@ func loginCmd() *cobra.Command {
 		Short: "Login to LLM service",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			c, err := configs.LoadOrCreate()
 			if err != nil {
 				return fmt.Errorf("load config: %s", err)
@@ -68,6 +68,11 @@ func loginCmd() *cobra.Command {
 				if !strings.Contains(err.Error(), "use of closed network connection") {
 					return err
 				}
+			}
+
+			fmt.Println("\nSetting the context...")
+			if err := context.Set(cmd.Context()); err != nil {
+				return err
 			}
 
 			return nil

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -47,7 +47,7 @@ func setCmd() *cobra.Command {
 		Use:  "set",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return set(cmd.Context())
+			return Set(cmd.Context())
 		},
 	}
 }
@@ -93,7 +93,8 @@ func get(ctx context.Context) error {
 	return nil
 }
 
-func set(ctx context.Context) error {
+// Set sets the organization and project context.
+func Set(ctx context.Context) error {
 	p := ui.NewPrompter()
 
 	env, err := runtime.NewEnv(ctx)


### PR DESCRIPTION
This minimizes some friction (e.g,. no need to specify --organization-title when running `llmo auth projects list`).