### PR TITLE
Include k8s namespace in the notebook URL

### DIFF
--- a/internal/workspaces/notebooks/notebooks.go
+++ b/internal/workspaces/notebooks/notebooks.go
@@ -285,7 +285,7 @@ func open(ctx context.Context, id string) error {
 	}
 
 	fmt.Println("Opening browser...")
-	nbURL := fmt.Sprintf("%s/sessions/%s/v1/services/notebooks/%s?token=%s", env.Config.EndpointURL, resp.ClusterId, id, token)
+	nbURL := fmt.Sprintf("%s/sessions/%s/v1/services/notebooks/%s/%s?token=%s", env.Config.EndpointURL, resp.ClusterId, id, resp.KubernetesNamespace, token)
 	return browser.OpenURL(nbURL)
 }
 


### PR DESCRIPTION
This change is required for session-manager-agent (Envoy) to route requests without ingress controller. As we need to construct a DNS name from the URL path, we need to know the namespace.

Corresponding change is made to job-manager (https://github.com/llm-operator/job-manager/pull/249).